### PR TITLE
Update runtime from nodejs18 to nodejs22

### DIFF
--- a/extension.yaml
+++ b/extension.yaml
@@ -47,7 +47,7 @@ resources:
         eventTrigger:
            eventType: google.storage.object.finalize
            resource: projects/_/buckets/${param:YOUR_BUCKET}
-        runtime: "nodejs18"
+        runtime: "nodejs22"
         availableMemoryMb: 1024
 
 params:


### PR DESCRIPTION
NodeJS 18 is decommissioned and cannot be deployed on GCP anymore